### PR TITLE
Stabilize build on Windows machines

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,7 @@ FROM golang:alpine
 RUN apk add --no-cache make git ca-certificates
 WORKDIR /app/src/mqtt-proxy
 COPY Makefile .deps ./
+RUN dos2unix .deps 
 RUN make deps-install
 
 COPY . .git ./


### PR DESCRIPTION
Added dos2unix for .deps, which may cause a build error, when Cloned on Windows.