### PR TITLE
Standalone Docker instruction not working

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ In API Gateway Policy Studio, please use Import Configuration Fragment to upload
 
 ## Command-line / Environment options
 ```sh
-docker run -it --rm mqtt-proxy davinci1976/mqtt-proxy mqtt-proxy --help
+docker run -it --rm davinci1976/mqtt-proxy mqtt-proxy --help
 ```
 
 ## Quickstart


### PR DESCRIPTION
When executing the line as given in the actual Read.me it leads to an error:

axway@api-env:~/github-projects> docker run -it --rm mqtt-proxy davinci1976/mqtt-proxy mqtt-proxy --help
Unable to find image 'mqtt-proxy:latest' locally



