### PR TITLE
Bugfix - MQTT-Payload was extracted into wrong attribute

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,7 @@ FROM golang:alpine
 RUN apk add --no-cache make git ca-certificates
 WORKDIR /app/src/mqtt-proxy
 COPY Makefile .deps ./
+RUN dos2unix .deps 
 RUN make deps-install
 
 COPY . .git ./

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,6 @@ FROM golang:alpine
 RUN apk add --no-cache make git ca-certificates
 WORKDIR /app/src/mqtt-proxy
 COPY Makefile .deps ./
-RUN dos2unix .deps 
 RUN make deps-install
 
 COPY . .git ./

--- a/api-gateway-policies/mqtt-proxy-apigw-policy.xml
+++ b/api-gateway-policies/mqtt-proxy-apigw-policy.xml
@@ -1496,7 +1496,7 @@
 			</key>
 		</key>
 	</key>
-	<fval name="attributeName"><value>mqtt.body</value></fval>
+	<fval name="attributeName"><value>mqtt.payload</value></fval>
 	<fval name="expression"><value>$.Payload</value></fval>
 	<fval name="failOnError"><value>0</value></fval>
 	<fval name="unmarshalType"><value>java.lang.String</value></fval>


### PR DESCRIPTION
On Receive-Action the MQTT-Payload was placed in the attribute: mqtt.body, which wasn't compatible to other parts (e.g. filter: Compare Attribute rename_topic_on_receive) of the policy. Changed attribute to mqtt.payload.